### PR TITLE
Chore: change underscore to lodash

### DIFF
--- a/NewPopover.js
+++ b/NewPopover.js
@@ -2,7 +2,7 @@
 
 import React, {PropTypes} from 'react';
 import {StyleSheet, Dimensions, Animated, Text, TouchableWithoutFeedback, View, Modal, Platform, Keyboard, Alert} from 'react-native';
-import _ from 'underscore';
+import _ from 'lodash';
 
 var flattenStyle = require('react-native/Libraries/StyleSheet/flattenStyle');
 var Easing = require('react-native/Libraries/Animated/src/Easing');

--- a/Popover.js
+++ b/Popover.js
@@ -12,7 +12,7 @@ import {
   Modal,
   Alert
 } from 'react-native';
-import _ from 'underscore';
+import _ from 'lodash';
 
 var noop = () => {};
 


### PR DESCRIPTION
Simply change the package underscore to lodash. Lodash is one of the default package which installed when initialising react native project. And it is same as underscore. This PR is cleaning the project package, the underscore page no long need be installed.